### PR TITLE
Version 0.2.2 - catch connection failures

### DIFF
--- a/couchrest_session_store.gemspec
+++ b/couchrest_session_store.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.files = `git ls-files`.split("\n")
   gem.name = "couchrest_session_store"
   gem.require_paths = ["lib"]
-  gem.version = '0.2.1'
+  gem.version = '0.2.2'
 
   gem.add_dependency "couchrest"
   gem.add_dependency "couchrest_model"

--- a/lib/couchrest/session/store.rb
+++ b/lib/couchrest/session/store.rb
@@ -62,6 +62,8 @@ class CouchRest::Session::Store < ActionDispatch::Session::AbstractStore
     doc = build_or_update_doc(sid, session, options)
     doc.save
     return sid
+  rescue CouchRest::Model::Errors::ConnectionFailed
+    return false
   end
 
   def destroy_session(env, sid, options)


### PR DESCRIPTION
If we can't connect to the couch return false on attempts to store the session.
This way the application does not crash.
It also keeps the cookie middleware from storing useless cookies and the
session store will not try to retrieve the session from the couch on the next
request.
