### PR TITLE
Feature/proceed if disconnected

### DIFF
--- a/couchrest_session_store.gemspec
+++ b/couchrest_session_store.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.files = `git ls-files`.split("\n")
   gem.name = "couchrest_session_store"
   gem.require_paths = ["lib"]
-  gem.version = '0.2.2'
+  gem.version = '0.2.3'
 
   gem.add_dependency "couchrest"
   gem.add_dependency "couchrest_model"

--- a/couchrest_session_store.gemspec
+++ b/couchrest_session_store.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.files = `git ls-files`.split("\n")
   gem.name = "couchrest_session_store"
   gem.require_paths = ["lib"]
-  gem.version = '0.2.3'
+  gem.version = '0.2.4'
 
   gem.add_dependency "couchrest"
   gem.add_dependency "couchrest_model"

--- a/lib/couchrest/session/store.rb
+++ b/lib/couchrest/session/store.rb
@@ -44,6 +44,12 @@ class CouchRest::Session::Store < ActionDispatch::Session::AbstractStore
   rescue RestClient::ResourceNotFound
     # session data does not exist anymore
     return [sid, {}]
+  rescue RestClient::Unauthorized,
+    Errno::EHOSTUNREACH,
+    Errno::ECONNREFUSED => e
+    # can't connect to couch. We add some status to the session
+    # so the app can react. (Display error for example)
+    return [sid, {"_status" => {"couch" => "unreachable"}}]
   end
 
   def set_session(env, sid, session, options)

--- a/lib/couchrest/session/store.rb
+++ b/lib/couchrest/session/store.rb
@@ -1,8 +1,8 @@
 class CouchRest::Session::Store < ActionDispatch::Session::AbstractStore
 
-  def initialize(app, options = {})
-    super
-    self.class.set_options(options)
+  # delegate configure to document
+  def self.configure(*args, &block)
+    CouchRest::Session::Document.configure *args, &block
   end
 
   def self.set_options(options)
@@ -10,6 +10,11 @@ class CouchRest::Session::Store < ActionDispatch::Session::AbstractStore
     if @options[:database]
       CouchRest::Session::Document.use_database @options[:database]
     end
+  end
+
+  def initialize(app, options = {})
+    super
+    self.class.set_options(options)
   end
 
   def cleanup(rows)


### PR DESCRIPTION
If someone already has a session id because they accessed the application and the couch goes down we don't want to crash but instead notify the app that we could not load the session properly.
