### PR TITLE
Bugfix/catch service unavailable

### DIFF
--- a/couchrest_session_store.gemspec
+++ b/couchrest_session_store.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.files = `git ls-files`.split("\n")
   gem.name = "couchrest_session_store"
   gem.require_paths = ["lib"]
-  gem.version = '0.3.0'
+  gem.version = '0.3.1'
 
   gem.add_dependency "couchrest"
   gem.add_dependency "couchrest_model"

--- a/lib/couchrest/session/store.rb
+++ b/lib/couchrest/session/store.rb
@@ -59,6 +59,7 @@ class CouchRest::Session::Store < ActionDispatch::Session::AbstractStore
     return sid
   # if we can't store the session we just return false.
   rescue RestClient::Unauthorized,
+    RestClient::ServiceUnavailable,
     Errno::EHOSTUNREACH,
     Errno::ECONNREFUSED => e
     return false


### PR DESCRIPTION
This way we still won't be able to use sessions while couch is offline
but at least the requests won't cause a 500 anymore and the landing page
will display nicely.

bump version to 0.3.1 so we can require this in the webapp
